### PR TITLE
pick registerMetrics() fn from Registry type for compatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -310,7 +310,9 @@ export function cacheKey(
   };
 }
 
-export function registerMetrics(registry: Registry): void {
+export function registerMetrics(
+  registry: Pick<Registry, "registerMetric">
+): void {
   registry.registerMetric(queryCount);
   registry.registerMetric(hitCount);
   registry.registerMetric(queryDuration);


### PR DESCRIPTION
only need registerMetrics() fn from Registry type, so using Pick method to make metrics flexible when using library